### PR TITLE
replace libparse in incorrect infinite range visitor

### DIFF
--- a/src/dscanner/analysis/incorrect_infinite_range.d
+++ b/src/dscanner/analysis/incorrect_infinite_range.d
@@ -13,85 +13,84 @@ import dparse.lexer;
 /**
  * Checks for incorrect infinite range definitions
  */
-final class IncorrectInfiniteRangeCheck : BaseAnalyzer
+extern(C++) class IncorrectInfiniteRangeCheck(AST) : BaseAnalyzerDmd!AST
 {
-	alias visit = BaseAnalyzer.visit;
+	alias visit = BaseAnalyzerDmd!AST.visit;
 
 	mixin AnalyzerInfo!"incorrect_infinite_range_check";
 
 	///
-	this(string fileName, bool skipTests = false)
+	extern(D) this(string fileName)
 	{
-		super(fileName, null, skipTests);
+		super(fileName);
 	}
 
-	override void visit(const StructBody structBody)
+	override void visit(AST.StructDeclaration sd)
 	{
-		inStruct++;
-		structBody.accept(this);
-		inStruct--;
+		inAggregate++;
+		super.visit(sd);
+		inAggregate--;
 	}
 
-	override void visit(const FunctionDeclaration fd)
+	override void visit(AST.ClassDeclaration cd)
 	{
-		if (inStruct > 0 && fd.name.text == "empty")
+		inAggregate++;
+		super.visit(cd);
+		inAggregate--;
+	}
+
+	override void visit(AST.FuncDeclaration fd)
+	{
+		import dmd.astenums : Tbool;
+
+		if (!inAggregate)
+			return;
+
+		if (!fd.ident || fd.ident.toString() != "empty")
+			return;
+
+		AST.TypeFunction tf = fd.type.isTypeFunction();
+
+		if (!tf || !tf.next || !tf.next.ty)
+			return;
+
+		AST.ReturnStatement rs = fd.fbody ? fd.fbody.isReturnStatement() : null;
+
+		if (rs)
 		{
-			line = fd.name.line;
-			column = fd.name.column;
-			fd.accept(this);
+			AST.IntegerExp ie = cast(AST.IntegerExp) rs.exp;
+
+			if (ie && ie.value == 0)
+				addErrorMessage(cast(ulong) fd.loc.linnum, cast(ulong) fd.loc.charnum, KEY,
+				"Use `enum bool empty = false;` to define an infinite range.");
 		}
+
+		AST.CompoundStatement cs = fd.fbody ? fd.fbody.isCompoundStatement() : null;
+		
+		if (!cs || (*cs.statements).length == 0)
+			return;
+
+		if (auto rs1 = (*cs.statements)[0].isReturnStatement())
+		{
+			AST.IntegerExp ie = cast(AST.IntegerExp) rs1.exp;
+
+			if (ie && ie.value == 0)
+				addErrorMessage(cast(ulong) fd.loc.linnum, cast(ulong) fd.loc.charnum, KEY,
+				"Use `enum bool empty = false;` to define an infinite range.");
+		}
+
+		super.visit(fd);
 	}
 
-	override void visit(const FunctionBody fb)
+	override void visit(AST.UnitTestDeclaration ud)
 	{
-		if (fb.specifiedFunctionBody && fb.specifiedFunctionBody.blockStatement !is null)
-			visit(fb.specifiedFunctionBody.blockStatement);
-		else if (fb.shortenedFunctionBody && fb.shortenedFunctionBody.expression !is null)
-			visitReturnExpression(fb.shortenedFunctionBody.expression);
-	}
-
-	override void visit(const BlockStatement bs)
-	{
-		if (bs.declarationsAndStatements is null)
-			return;
-		if (bs.declarationsAndStatements.declarationsAndStatements is null)
-			return;
-		if (bs.declarationsAndStatements.declarationsAndStatements.length != 1)
-			return;
-		visit(bs.declarationsAndStatements);
-	}
-
-	override void visit(const ReturnStatement rs)
-	{
-		if (inStruct == 0 || line == size_t.max) // not within a struct yet
-			return;
-		visitReturnExpression(rs.expression);
-	}
-
-	void visitReturnExpression(const Expression expression)
-	{
-		if (!expression || expression.items.length != 1)
-			return;
-		UnaryExpression unary = cast(UnaryExpression) expression.items[0];
-		if (unary is null)
-			return;
-		if (unary.primaryExpression is null)
-			return;
-		if (unary.primaryExpression.primary != tok!"false")
-			return;
-		addErrorMessage(line, column, KEY, MESSAGE);
-	}
-
-	override void visit(const Unittest u)
-	{
+		
 	}
 
 private:
-	uint inStruct;
+	uint inAggregate;
 	enum string KEY = "dscanner.suspicious.incorrect_infinite_range";
 	enum string MESSAGE = "Use `enum bool empty = false;` to define an infinite range.";
-	size_t line = size_t.max;
-	size_t column;
 }
 
 unittest
@@ -102,9 +101,9 @@ unittest
 
 	StaticAnalysisConfig sac = disabledConfig();
 	sac.incorrect_infinite_range_check = Check.enabled;
-	assertAnalyzerWarnings(q{struct InfiniteRange
+	assertAnalyzerWarningsDMD(q{struct InfiniteRange
 {
-	bool empty() // [warn]: %1$s
+	bool empty() // [warn]: Use `enum bool empty = false;` to define an infinite range.
 	{
 		return false;
 	}
@@ -128,7 +127,7 @@ unittest
 
 struct InfiniteRange
 {
-	bool empty() => false; // [warn]: %1$s
+	bool empty() => false; // [warn]: Use `enum bool empty = false;` to define an infinite range.
 	bool stuff() => false;
 	unittest
 	{
@@ -143,10 +142,9 @@ struct InfiniteRange
 }
 
 bool empty() { return false; }
-class C { bool empty() { return false; } } // [warn]: %1$s
+class C { bool empty() { return false; } } // [warn]: Use `enum bool empty = false;` to define an infinite range.
 
-}c
-			.format(IncorrectInfiniteRangeCheck.MESSAGE), sac);
+}c, sac);
 }
 
 // test for https://github.com/dlang-community/D-Scanner/issues/656
@@ -167,7 +165,7 @@ unittest
 
 	StaticAnalysisConfig sac = disabledConfig();
 	sac.incorrect_infinite_range_check = Check.enabled;
-	assertAnalyzerWarnings(q{
+	assertAnalyzerWarningsDMD(q{
 		enum isAllZeroBits = ()
 		{
 			if (true)

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -565,10 +565,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new AutoRefAssignmentCheck(fileName,
 		analysisConfig.auto_ref_assignment_check == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!IncorrectInfiniteRangeCheck(analysisConfig))
-		checks ~= new IncorrectInfiniteRangeCheck(fileName,
-		analysisConfig.incorrect_infinite_range_check == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!UselessAssertCheck(analysisConfig))
 		checks ~= new UselessAssertCheck(fileName,
 		analysisConfig.useless_assert_check == Check.skipTests && !ut);
@@ -680,6 +676,9 @@ MessageSet analyzeDmd(string fileName, ASTBase.Module m, const char[] moduleName
 
 	if (moduleName.shouldRunDmd!(FinalAttributeChecker!ASTBase)(config))
 		visitors ~= new FinalAttributeChecker!ASTBase(fileName);
+
+	if (moduleName.shouldRunDmd!(IncorrectInfiniteRangeCheck!ASTBase)(config))
+		visitors ~= new IncorrectInfiniteRangeCheck!ASTBase(fileName);
 
 	foreach (visitor; visitors)
 	{


### PR DESCRIPTION
This visitor checks all function declarations inside either a class or a struct, functions named empty. For Func Declarations we are inspecting the return statements. 