### PR TITLE
replace libdparse in alias style visitor

### DIFF
--- a/src/dscanner/analysis/alias_syntax_check.d
+++ b/src/dscanner/analysis/alias_syntax_check.d
@@ -5,35 +5,59 @@
 
 module dscanner.analysis.alias_syntax_check;
 
-import dparse.ast;
-import dparse.lexer;
 import dscanner.analysis.base;
+import dmd.tokens;
+import dmd.lexer : Lexer;
+import dmd.globals : Loc;
 
 /**
  * Checks for uses of the old alias syntax.
  */
-final class AliasSyntaxCheck : BaseAnalyzer
+extern(C++) class AliasSyntaxCheck(AST) : BaseAnalyzerDmd!AST
 {
-	alias visit = BaseAnalyzer.visit;
-
 	mixin AnalyzerInfo!"alias_syntax_check";
+	alias visit = BaseAnalyzerDmd!AST.visit;
 
-	this(string fileName, bool skipTests = false)
+	extern(D) this(string fileName)
 	{
-		super(fileName, null, skipTests);
+		super(fileName);
 	}
 
-	override void visit(const AliasDeclaration ad)
+	override void visit(AST.AliasDeclaration ad)
 	{
-		if (ad.declaratorIdentifierList is null)
-			return;
-		assert(ad.declaratorIdentifierList.identifiers.length > 0,
-				"Identifier list length is zero, libdparse has a bug");
-		addErrorMessage(ad.declaratorIdentifierList.identifiers[0].line,
-				ad.declaratorIdentifierList.identifiers[0].column, KEY,
-				"Prefer the new \"'alias' identifier '=' type ';'\" syntax"
-				~ " to the  old \"'alias' type identifier ';'\" syntax.");
+		import dscanner.utils: readFile;
+
+		auto bytes = readFile(fileName);
+		bool foundEq = false;
+		Loc idLoc;
+
+		bytes ~= "\0";
+		bytes = bytes[ad.loc.fileOffset .. $];
+
+		scope lexer = new Lexer(null, cast(char*) bytes, 0, bytes.length, 0, 0);
+		TOK nextTok;
+		lexer.nextToken();
+
+		do
+		{
+			if (lexer.token.value == TOK.assign)
+				foundEq = true;
+
+			if (lexer.token.value == TOK.identifier)
+				idLoc = lexer.token.loc;
+
+			nextTok = lexer.nextToken;
+		}
+		while(nextTok != TOK.semicolon && nextTok != TOK.endOfFile);
+
+		if (!foundEq)
+			// Re-lexing is done based on offsets, so the alias appears to be at line 1.
+			// Fix this by computing the initial location.
+			addErrorMessage(cast(ulong) (ad.loc.linnum + idLoc.linnum - 1), cast(ulong) idLoc.charnum, KEY,
+							"Prefer the new \"'alias' identifier '=' type ';'\" syntax"
+							~ " to the  old \"'alias' type identifier ';'\" syntax.");
 	}
+
 
 private:
 	enum KEY = "dscanner.style.alias_syntax";
@@ -41,7 +65,7 @@ private:
 
 unittest
 {
-	import dscanner.analysis.helpers : assertAnalyzerWarnings;
+	import dscanner.analysis.helpers : assertAnalyzerWarnings = assertAnalyzerWarningsDMD;
 	import dscanner.analysis.config : StaticAnalysisConfig, Check, disabledConfig;
 	import std.stdio : stderr;
 

--- a/src/dscanner/analysis/helpers.d
+++ b/src/dscanner/analysis/helpers.d
@@ -150,11 +150,24 @@ void assertAnalyzerWarningsDMD(string code, const StaticAnalysisConfig config,
 	import dmd.identifier : Identifier;
 	import std.string : toStringz;
 	import dscanner.utils : getModuleName;
+	import std.file : remove, exists;
+	import std.stdio : File;
 
 	Id.initialize();
 	global._init();
 	global.params.useUnitTests = true;
 	ASTBase.Type._init();
+
+	auto deleteme = "test.txt";
+	File temp = File(deleteme, "w");
+	scope(exit)
+	{
+		assert(exists(deleteme));
+		remove(deleteme);
+	}
+
+	temp.write(code);
+	temp.close();
 
 	auto id = Identifier.idPool(file);
 	auto ast_m = new ASTBase.Module(file.toStringz, id, false, false);
@@ -163,7 +176,7 @@ void assertAnalyzerWarningsDMD(string code, const StaticAnalysisConfig config,
 	scope astbaseParser = new Parser!ASTBase(ast_m, input, false);
 	astbaseParser.nextToken();
 	ast_m.members = astbaseParser.parseModule();
-	MessageSet rawWarnings = analyzeDmd("test", ast_m, getModuleName(astbaseParser.md), config);
+	MessageSet rawWarnings = analyzeDmd("test.txt", ast_m, getModuleName(astbaseParser.md), config);
 
 	string[] codeLines = code.splitLines();
 

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -565,10 +565,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new UselessAssertCheck(fileName,
 		analysisConfig.useless_assert_check == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!AliasSyntaxCheck(analysisConfig))
-		checks ~= new AliasSyntaxCheck(fileName,
-		analysisConfig.alias_syntax_check == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!StaticIfElse(analysisConfig))
 		checks ~= new StaticIfElse(fileName,
 		analysisConfig.static_if_else_check == Check.skipTests && !ut);
@@ -676,6 +672,9 @@ MessageSet analyzeDmd(string fileName, ASTBase.Module m, const char[] moduleName
 		
 	if (moduleName.shouldRunDmd!(LengthSubtractionCheck!ASTBase)(config))
 		visitors ~= new LengthSubtractionCheck!ASTBase(fileName);
+		
+	if (moduleName.shouldRunDmd!(AliasSyntaxCheck!ASTBase)(config))
+		visitors ~= new AliasSyntaxCheck!ASTBase(fileName);
 
 	foreach (visitor; visitors)
 	{


### PR DESCRIPTION
This check look for constructions like `alias type identifier`
To achieve that, for all `AliasDeclaration` we extract the tokens until `;` is found, and we look for the `=` token. If we don't find any, it means that we have an `alias type identifier` construction

This also includes the modifications from https://github.com/Dlang-UPB/D-scanner/pull/36 (helpers.d)