### PR TITLE
replace libdparse in constructor check

### DIFF
--- a/changelog/dscanner.struct-ctor-check.dd
+++ b/changelog/dscanner.struct-ctor-check.dd
@@ -1,0 +1,19 @@
+Remove the check regarding structs with no arguments constructors.
+
+The check is implemented in constructors.d and it warns against the usage
+of both constructors with all parameters with default values and constructors
+without any arguments, as this might be confusing. This scenario, for structs,
+is no longer D valid code and that's why it is being deprecated.
+
+Let's consider the following code:
+
+---
+struct Dog
+{
+	this() {}
+	this(string name = "doggie") {} // [warn]: This struct constructor can never be called with its default argument.
+}
+---
+
+D-Scanner would throw and error for this particular struct, but this code
+does not compile anymore hence this check is not needed anymore/

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -476,10 +476,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new CommaExpressionCheck(fileName, moduleScope,
 		analysisConfig.comma_expression_check == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!ConstructorCheck(analysisConfig))
-		checks ~= new ConstructorCheck(fileName, moduleScope,
-		analysisConfig.constructor_check == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!UnmodifiedFinder(analysisConfig))
 		checks ~= new UnmodifiedFinder(fileName, moduleScope,
 		analysisConfig.could_be_immutable_check == Check.skipTests && !ut);
@@ -676,6 +672,9 @@ MessageSet analyzeDmd(string fileName, ASTBase.Module m, const char[] moduleName
 		
 	if (moduleName.shouldRunDmd!(LengthSubtractionCheck!ASTBase)(config))
 		visitors ~= new LengthSubtractionCheck!ASTBase(fileName);
+
+	if (moduleName.shouldRunDmd!(ConstructorCheck!ASTBase)(config))
+		visitors ~= new ConstructorCheck!ASTBase(fileName);
 
 	foreach (visitor; visitors)
 	{


### PR DESCRIPTION
Problematic code:
```
class Cat // [warn]: This class has a zero-argument constructor as well as a constructor with one default argument. This can be confusing.
		{
			this() {}
			this(string name = "kittie") {}
		}

		struct Dog
		{
			this() {}
			this(string name = "doggie") {} // [warn]: This struct constructor can never be called with its default argument.
		}
```

For this check, we keep track if we are inside a class or struct, and then do a simple check for constructors(check if it has no args, or 1 arg with a default value)