### PR TITLE
replace libparse in opequals without tohash visitor

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -516,10 +516,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new NumberStyleCheck(fileName, moduleScope,
 		analysisConfig.number_style_check == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!OpEqualsWithoutToHashCheck(analysisConfig))
-		checks ~= new OpEqualsWithoutToHashCheck(fileName, moduleScope,
-		analysisConfig.opequals_tohash_check == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!RedundantParenCheck(analysisConfig))
 		checks ~= new RedundantParenCheck(fileName, moduleScope,
 		analysisConfig.redundant_parens_check == Check.skipTests && !ut);
@@ -674,6 +670,12 @@ MessageSet analyzeDmd(string fileName, ASTBase.Module m, const char[] moduleName
 
 	if (moduleName.shouldRunDmd!(LocalImportCheck!ASTBase)(config))
 		visitors ~= new LocalImportCheck!ASTBase(fileName);
+
+	if (moduleName.shouldRunDmd!(OpEqualsWithoutToHashCheck!ASTBase)(config))
+		visitors ~= new OpEqualsWithoutToHashCheck!ASTBase(
+			fileName,
+			config.opequals_tohash_check == Check.skipTests && !ut
+		);
 
 	foreach (visitor; visitors)
 	{


### PR DESCRIPTION
Same as: https://github.com/Dlang-UPB/D-scanner/pull/19

Problematic code:
```
class Rabbit // [warn]: 'Rabbit' has method 'opEquals', but not 'toHash'.
{
	const bool opEquals(Object a, Object b)
	{
		return true;
	}
}
```