### PR TITLE
replace libdparse in exception check visitor

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -480,10 +480,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new DuplicateAttributeCheck(fileName, moduleScope,
 		analysisConfig.duplicate_attribute == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!PokemonExceptionCheck(analysisConfig))
-		checks ~= new PokemonExceptionCheck(fileName, moduleScope,
-		analysisConfig.exception_check == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!FloatOperatorCheck(analysisConfig))
 		checks ~= new FloatOperatorCheck(fileName, moduleScope,
 		analysisConfig.float_operator_check == Check.skipTests && !ut);
@@ -676,6 +672,12 @@ MessageSet analyzeDmd(string fileName, ASTBase.Module m, const char[] moduleName
 	
 	if (moduleName.shouldRunDmd!(BuiltinPropertyNameCheck!ASTBase)(config))
 		visitors ~= new BuiltinPropertyNameCheck!ASTBase(fileName);
+
+	if (moduleName.shouldRunDmd!(PokemonExceptionCheck!ASTBase)(config))
+		visitors ~= new PokemonExceptionCheck!ASTBase(
+			fileName,
+			config.exception_check == Check.skipTests && !ut
+		);
 
 	foreach (visitor; visitors)
 	{


### PR DESCRIPTION
Problematic code:
```
// ...
catch (Error err) // [warn]: Catching Error or Throwable is almost always a bad idea.
{

}
catch (Throwable err) // [warn]: Catching Error or Throwable is almost always a bad idea.
{

}
```

I also deleted from the unittest the part where an empty `catch` is used, as this is not valid syntax anymore