### PR TITLE
replace libdparse in static if else visitor

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -538,10 +538,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new UselessAssertCheck(fileName,
 		analysisConfig.useless_assert_check == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!StaticIfElse(analysisConfig))
-		checks ~= new StaticIfElse(fileName,
-		analysisConfig.static_if_else_check == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!LambdaReturnCheck(analysisConfig))
 		checks ~= new LambdaReturnCheck(fileName,
 		analysisConfig.lambda_return_check == Check.skipTests && !ut);
@@ -686,6 +682,12 @@ MessageSet analyzeDmd(string fileName, ASTCodegen.Module m, const char[] moduleN
 		visitors ~= new RedundantParenCheck!ASTCodegen(
 			fileName,
 			config.redundant_parens_check == Check.skipTests && !ut
+		);
+
+	if (moduleName.shouldRunDmd!(StaticIfElse!ASTCodegen)(config))
+		visitors ~= new StaticIfElse!ASTCodegen(
+			fileName,
+			config.static_if_else_check == Check.skipTests && !ut
 		);
 
 	foreach (visitor; visitors)


### PR DESCRIPTION
Problematic code:
```
void foo() {
        static if (false)
	       auto a = 0;
	else if (true) // [warn]: Mismatched static if. Use 'else static if' here.
		auto b = 1;
	}
```
This check suggests that even one might want to use a construction similar to the one above, in most cases these constructions can lead to mistakes