### PR TITLE
replace libdparse in redundant storage class visitor

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -578,10 +578,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new TrustTooMuchCheck(fileName,
 		analysisConfig.trust_too_much == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!RedundantStorageClassCheck(analysisConfig))
-		checks ~= new RedundantStorageClassCheck(fileName,
-		analysisConfig.redundant_storage_classes == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!UnusedResultChecker(analysisConfig))
 		checks ~= new UnusedResultChecker(fileName, moduleScope,
 		analysisConfig.unused_result == Check.skipTests && !ut);
@@ -684,6 +680,12 @@ MessageSet analyzeDmd(string fileName, ASTCodegen.Module m, const char[] moduleN
 		visitors ~= new ProperlyDocumentedPublicFunctions!ASTCodegen(
 			fileName,
 			config.properly_documented_public_functions == Check.skipTests && !ut
+		);
+
+	if (moduleName.shouldRunDmd!(RedundantStorageClassCheck!ASTCodegen)(config))
+		visitors ~= new RedundantStorageClassCheck!ASTCodegen(
+			fileName,
+			config.redundant_storage_classes == Check.skipTests && !ut
 		);
 
 	foreach (visitor; visitors)


### PR DESCRIPTION
For this check we are looking for variables that has 2 of the following attributes: `immutable`, `shared`, `static`, `__gshared`. I also added the check for `StorageClassDeclaration` to catch situations like:
```
class C {
    immutable:
        shared int a;
}
```
Situations which are unlikely, but possible