### PR TITLE
replace libdparse in unused label check

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -517,10 +517,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new UndocumentedDeclarationCheck(fileName, moduleScope,
 		analysisConfig.undocumented_declaration_check == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!UnusedLabelCheck(analysisConfig))
-		checks ~= new UnusedLabelCheck(fileName, moduleScope,
-		analysisConfig.unused_label_check == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!UnusedVariableCheck(analysisConfig))
 		checks ~= new UnusedVariableCheck(fileName, moduleScope,
 		analysisConfig.unused_variable_check == Check.skipTests && !ut);
@@ -661,6 +657,12 @@ MessageSet analyzeDmd(string fileName, ASTCodegen.Module m, const char[] moduleN
 		visitors ~= new LogicPrecedenceCheck!ASTCodegen(
 			fileName,
 			config.logical_precedence_check == Check.skipTests && !ut
+		);
+	
+	if (moduleName.shouldRunDmd!(UnusedLabelCheck!ASTCodegen)(config))
+		visitors ~= new UnusedLabelCheck!ASTCodegen(
+			fileName,
+			config.unused_label_check == Check.skipTests && !ut
 		);
 	
 	if (moduleName.shouldRunDmd!(BuiltinPropertyNameCheck!ASTCodegen)(config))


### PR DESCRIPTION
This PR is not yet ready for review as currently D-Scanner can't be build because of some updates in dmd (will need to update include paths, makefile, update a few files, and also probably update some dub packages). As this might take some time, I am currently using an older dmd version for local development and testing, but the github integration tests will fail until I fix the aforementioned issues

Example problematic code:

```
int testUnusedLabel()
{
		int x = 0;
A: // [warn]: Label "A" is not used.
	        if (x) goto B;
B:
	        x++;
}
```