### PR TITLE
replace libdparse in trust_too_much visitor

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -554,10 +554,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new IfConstraintsIndentCheck(fileName, tokens,
 		analysisConfig.if_constraints_indent == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!TrustTooMuchCheck(analysisConfig))
-		checks ~= new TrustTooMuchCheck(fileName,
-		analysisConfig.trust_too_much == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!RedundantStorageClassCheck(analysisConfig))
 		checks ~= new RedundantStorageClassCheck(fileName,
 		analysisConfig.redundant_storage_classes == Check.skipTests && !ut);
@@ -640,6 +636,12 @@ MessageSet analyzeDmd(string fileName, ASTCodegen.Module m, const char[] moduleN
 		visitors ~= new OpEqualsWithoutToHashCheck!ASTCodegen(
 			fileName,
 			config.opequals_tohash_check == Check.skipTests && !ut
+		);
+
+	if (moduleName.shouldRunDmd!(TrustTooMuchCheck!ASTCodegen)(config))
+		visitors ~= new TrustTooMuchCheck!ASTCodegen(
+			fileName,
+			config.trust_too_much == Check.skipTests && !ut
 		);
 		
 	if (moduleName.shouldRunDmd!(AutoRefAssignmentCheck!ASTCodegen)(config))

--- a/src/dscanner/analysis/trust_too_much.d
+++ b/src/dscanner/analysis/trust_too_much.d
@@ -5,88 +5,50 @@
 
 module dscanner.analysis.trust_too_much;
 
-import std.stdio;
-import dparse.ast;
-import dparse.lexer;
 import dscanner.analysis.base;
-import dsymbol.scope_;
+import dmd.astenums : STC;
 
 /**
  * Checks that `@trusted` is only applied to a a single function
  */
-final class TrustTooMuchCheck : BaseAnalyzer
+extern(C++) class TrustTooMuchCheck(AST) : BaseAnalyzerDmd
 {
+	mixin AnalyzerInfo!"trust_too_much";
+	alias visit = BaseAnalyzerDmd.visit;
+
 private:
-
-	static immutable MESSAGE = "Trusting a whole scope is a bad idea, " ~
+	extern(D) static immutable MESSAGE = "Trusting a whole scope is a bad idea, " ~
 		"`@trusted` should only be attached to the functions individually";
-	static immutable string KEY = "dscanner.trust_too_much";
-
-	bool checkAtAttribute = true;
+	extern(D) static immutable string KEY = "dscanner.trust_too_much";
 
 public:
-
-	alias visit = BaseAnalyzer.visit;
-
-	mixin AnalyzerInfo!"trust_too_much";
-
 	///
-	this(string fileName, bool skipTests = false)
+	extern(D) this(string fileName, bool skipTests = false)
 	{
-		super(fileName, sc, skipTests);
+		super(fileName, skipTests);
 	}
 
-	override void visit(const AtAttribute d)
+	override void visit(AST.StorageClassDeclaration scd)
 	{
-		if (checkAtAttribute && d.identifier.text == "trusted")
-		{
-			const Token t = d.identifier;
-			addErrorMessage(t.line, t.column, KEY, MESSAGE);
-		}
-		d.accept(this);
-	}
-
-	// always applied to function body, so OK
-	override void visit(const MemberFunctionAttribute d)
-	{
-		const oldCheckAtAttribute = checkAtAttribute;
-		checkAtAttribute = false;
-		d.accept(this);
-		checkAtAttribute = oldCheckAtAttribute;
-	}
-
-	// handles `@trusted{}` and old style, leading, atAttribute for single funcs
-	override void visit(const Declaration d)
-	{
-		const oldCheckAtAttribute = checkAtAttribute;
-
-		checkAtAttribute = 	d.functionDeclaration is null && d.unittest_ is null &&
-							d.constructor is null && d.destructor is null &&
-							d.staticConstructor is null && d.staticDestructor is null &&
-							d.sharedStaticConstructor is null && d.sharedStaticDestructor is null;
-		d.accept(this);
-		checkAtAttribute = oldCheckAtAttribute;
-	}
-
-	// issue #588
-	override void visit(const AliasDeclaration d)
-	{
-		const oldCheckAtAttribute = checkAtAttribute;
-		checkAtAttribute = false;
-		d.accept(this);
-		checkAtAttribute = oldCheckAtAttribute;
+		if (scd.stc & STC.trusted)
+			addErrorMessage(cast(ulong) scd.loc.linnum, cast(ulong) scd.loc.charnum,
+					KEY, MESSAGE);
+	
+			super.visit(scd);
 	}
 }
 
 unittest
 {
 	import dscanner.analysis.config : StaticAnalysisConfig, Check, disabledConfig;
-	import dscanner.analysis.helpers : assertAnalyzerWarnings;
+	import dscanner.analysis.helpers : assertAnalyzerWarnings = assertAnalyzerWarningsDMD;
 	import std.format : format;
+	import std.stdio : stderr;
 
 	StaticAnalysisConfig sac = disabledConfig();
 	sac.trust_too_much = Check.enabled;
-	const msg = TrustTooMuchCheck.MESSAGE;
+	const msg = "Trusting a whole scope is a bad idea, " ~
+		"`@trusted` should only be attached to the functions individually";
 
 	//--- fail cases ---//
 


### PR DESCRIPTION
This check warns against trusting a whole scope
```
struct foo{
	@trusted:  // [warn]
	void foo() {}
}
```