### PR TITLE
replace libdparse in unused result visitor

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -553,10 +553,6 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 		checks ~= new RedundantStorageClassCheck(fileName,
 		analysisConfig.redundant_storage_classes == Check.skipTests && !ut);
 
-	if (moduleName.shouldRun!UnusedResultChecker(analysisConfig))
-		checks ~= new UnusedResultChecker(fileName, moduleScope,
-		analysisConfig.unused_result == Check.skipTests && !ut);
-
 	if (moduleName.shouldRun!CyclomaticComplexityCheck(analysisConfig))
 		checks ~= new CyclomaticComplexityCheck(fileName, moduleScope,
 		analysisConfig.cyclomatic_complexity == Check.skipTests && !ut,
@@ -679,6 +675,12 @@ MessageSet analyzeDmd(string fileName, ASTCodegen.Module m, const char[] moduleN
 		visitors ~= new RedundantParenCheck!ASTCodegen(
 			fileName,
 			config.redundant_parens_check == Check.skipTests && !ut
+		);
+
+	if (moduleName.shouldRunDmd!(UnusedResultChecker!ASTCodegen)(config))
+		visitors ~= new UnusedResultChecker!ASTCodegen(
+			fileName,
+			config.unused_result == Check.skipTests && !ut
 		);
 
 	if (moduleName.shouldRunDmd!(StaticIfElse!ASTCodegen)(config))


### PR DESCRIPTION
This check looks for situations where the return value of non-void functions is ignored. Example:
```
int fun() { return 1; }
void main()
{
        fun(); // [warn]: Function return value is discarded
}
```

In order to achieve that I decided to check `CompoundStatement` as this statement is encountered every time we have a set of instructions inside `{ }`. Ex: `for(...) {}`, `void f() {// CompoundStatement}` and if we encounter directly a `CallExp`, it means that the return value is ignored.

I also checked instructions where we have only 1 statement, without `{ }`, like:
```
if (true)
        foo()
```