### PR TITLE
Replace libdparse with DMD in AlwaysCurlyCheck

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -878,10 +878,6 @@ private BaseAnalyzer[] getAnalyzersForModuleAndConfig(string fileName,
 		checks ~= new AllManCheck(args.setSkipTests(
 		analysisConfig.allman_braces_check == Check.skipTests && !ut));
 
-	if (moduleName.shouldRun!AlwaysCurlyCheck(analysisConfig))
-		checks ~= new AlwaysCurlyCheck(args.setSkipTests(
-		analysisConfig.always_curly_check == Check.skipTests && !ut));
-
 	if (moduleName.shouldRun!HasPublicExampleCheck(analysisConfig))
 		checks ~= new HasPublicExampleCheck(args.setSkipTests(
 		analysisConfig.has_public_example == Check.skipTests && !ut));
@@ -1342,6 +1338,12 @@ MessageSet analyzeDmd(string fileName, ASTCodegen.Module m, const char[] moduleN
 		visitors ~= new LambdaReturnCheck!ASTCodegen(
 			fileName,
 			config.lambda_return_check == Check.skipTests && !ut
+		);
+
+	if (moduleName.shouldRunDmd!(AlwaysCurlyCheck!ASTCodegen)(config))
+		visitors ~= new AlwaysCurlyCheck!ASTCodegen(
+			fileName,
+			config.always_curly_check == Check.skipTests && !ut
 		);
 
 	foreach (visitor; visitors)


### PR DESCRIPTION
This check ensures some statements (if, for, foreach, while, do, try-catch) are always written with braces. My solution is to visit Compound statements and mark their parent as having braces, since compound statements in DMD are statements having more than 1 child statement (forcing a brace block).
AST node changes include:
- libdparse BlockStatement => DMD CompoundStatement;
- libdparse ForeachStatement => DMD ForeachStatement and ForeachRangeStatement;
- libdparse TryStatement => DMD TryCatchStatement (try statement with catch blocks) and TryFinallyStatement (try statement with finally block).

For visiting the common statements I have created a template.
For TryCatchStatement and TryFinallyStatement  I have created separated visit functions because:
- a try with only catch blocks and no finally block is a TryCatchStatement ;
- a try with a finally block and no catches is a TryFinallyStatement  ;
- a try with catch blocks and finally statement is a TryFinallyStatement having a TryCatchStatement as a child.
So, for a TryCatchStatement => check the try block and each catch block.
For a TryFinallyStatement, if the tryBody is a TryCatchStatement  => just visit the block, if not also check it; check the finally block.

I've also extended the unit tests by adding test cases for passing scenarios and a test case for a try-catch-finally statement.