### PR TITLE
Replace libdparse with DMD in UnusedParameterCheck

### DIFF
--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -849,10 +849,6 @@ private BaseAnalyzer[] getAnalyzersForModuleAndConfig(string fileName,
 		checks ~= new UnusedVariableCheck(args.setSkipTests(
 		analysisConfig.unused_variable_check == Check.skipTests && !ut));
 
-	if (moduleName.shouldRun!UnusedParameterCheck(analysisConfig))
-		checks ~= new UnusedParameterCheck(args.setSkipTests(
-		analysisConfig.unused_parameter_check == Check.skipTests && !ut));
-
 	if (moduleName.shouldRun!LineLengthCheck(analysisConfig))
 		checks ~= new LineLengthCheck(args.setSkipTests(
 		analysisConfig.long_line_check == Check.skipTests && !ut),
@@ -1348,6 +1344,12 @@ MessageSet analyzeDmd(string fileName, ASTCodegen.Module m, const char[] moduleN
 		visitors ~= new AutoFunctionChecker!ASTCodegen(
 			fileName,
 			config.auto_function_check == Check.skipTests && !ut
+		);
+
+	if (moduleName.shouldRunDmd!(UnusedParameterCheck!ASTCodegen)(config))
+		visitors ~= new UnusedParameterCheck!ASTCodegen(
+			fileName,
+			config.unused_parameter_check == Check.skipTests && !ut
 		);
 
 	foreach (visitor; visitors)

--- a/src/dscanner/analysis/unused_parameter.d
+++ b/src/dscanner/analysis/unused_parameter.d
@@ -144,7 +144,14 @@ extern (C++) class UnusedParameterCheck(AST) : BaseAnalyzerDmd
 
 	private void pushScope()
 	{
-		usedParams ~= new ParamSet;
+		// Error with gdc-12
+		//usedParams ~= new ParamSet;
+
+		// Workaround for gdc-12
+		ParamSet newScope;
+		newScope["test"] = ParamInfo("test", 0, 0);
+		usedParams ~= newScope;
+		currentScope.remove("test");
 	}
 
 	private void popScope()

--- a/src/dscanner/analysis/unused_parameter.d
+++ b/src/dscanner/analysis/unused_parameter.d
@@ -4,52 +4,152 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 module dscanner.analysis.unused_parameter;
 
-import dparse.ast;
-import dparse.lexer;
 import dscanner.analysis.base;
-import dscanner.analysis.unused;
-import dsymbol.scope_ : Scope;
+import dmd.astenums : STC;
+import std.algorithm : all, canFind, each, filter, map;
+import std.conv : to;
 
 /**
- * Checks for unused variables.
+ * Checks for unused function parameters.
  */
-final class UnusedParameterCheck : UnusedStorageCheck
+extern (C++) class UnusedParameterCheck(AST) : BaseAnalyzerDmd
 {
-	alias visit = UnusedStorageCheck.visit;
-
+	alias visit = BaseAnalyzerDmd.visit;
 	mixin AnalyzerInfo!"unused_parameter_check";
 
-	/**
-	 * Params:
-	 *     fileName = the name of the file being analyzed
-	 */
-	this(BaseAnalyzerArguments args)
+	private enum KEY = "dscanner.suspicious.unused_parameter";
+	private enum MSG = "Parameter %s is never used.";
+
+	private static struct ParamInfo
 	{
-		super(args, "Parameter", "unused_parameter");
+		string name;
+		ulong lineNum;
+		ulong charNum;
+		bool isUsed = false;
 	}
 
-	override void visit(const Parameter parameter)
+	private alias ParamSet = ParamInfo[string];
+	private ParamSet[] usedParams;
+	private bool inMixin;
+
+	extern (D) this(string fileName, bool skipTests = false)
 	{
-		import std.algorithm : among;
-		import std.algorithm.iteration : filter;
-		import std.range : empty;
+		super(fileName, skipTests);
+		pushScope();
+	}
 
-		if (parameter.name != tok!"")
+	override void visit(AST.FuncDeclaration funcDeclaration)
+	{
+		import std.format : format;
+
+		pushScope();
+		super.visit(funcDeclaration);
+
+		bool shouldIgnoreWarns = funcDeclaration.fbody is null || funcDeclaration.storage_class & STC.override_;
+		if (!shouldIgnoreWarns)
+			currentScope.byValue
+				.filter!(param => !param.isUsed)
+				.each!(param => addErrorMessage(param.lineNum, param.charNum, KEY, MSG.format(param.name)));
+
+		popScope();
+	}
+
+	override void visit(AST.Parameter parameter)
+	{
+		import dmd.astenums : TY;
+
+		if (parameter.ident is null)
+			return;
+
+		auto varName = cast(string) parameter.ident.toString();
+		bool shouldBeIgnored = varName.all!(c => c == '_') || parameter.storageClass & STC.ref_
+			|| parameter.storageClass & STC.out_ || parameter.type.ty == TY.Tpointer;
+		if (!shouldBeIgnored)
+			currentScope[varName] = ParamInfo(varName, parameter.loc.linnum, parameter.loc.charnum);
+	}
+
+	override void visit(AST.TypeSArray newExp)
+	{
+		if (auto identifierExpression = newExp.dim.isIdentifierExp())
+			identifierExpression.accept(this);
+	}
+
+	override void visit(AST.IdentifierExp identifierExp)
+	{
+		if (identifierExp.ident)
+			markAsUsed(cast(string) identifierExp.ident.toString());
+
+		super.visit(identifierExp);
+	}
+
+	mixin VisitMixin!(AST.MixinExp);
+	mixin VisitMixin!(AST.MixinStatement);
+
+	private template VisitMixin(NodeType)
+	{
+		override void visit(NodeType node)
 		{
-			immutable bool isRef = !parameter.parameterAttributes
-				.filter!(a => a.idType.among(tok!"ref", tok!"out")).empty;
-			immutable bool isPtr = parameter.type && !parameter.type
-				.typeSuffixes.filter!(a => a.star != tok!"").empty;
+			inMixin = true;
+			super.visit(node);
+			inMixin = false;
+		}
+	}
 
-			variableDeclared(parameter.name.text, parameter.name, isRef | isPtr);
+	override void visit(AST.StringExp stringExp)
+	{
+		if (!inMixin)
+			return;
 
-			if (parameter.default_ !is null)
+		string str = cast(string) stringExp.toStringz();
+		currentScope.byKey
+			.filter!(param => canFind(str, param))
+			.each!(param => markAsUsed(param));
+	}
+
+	override void visit(AST.TraitsExp traitsExp)
+	{
+		import dmd.dtemplate : isType;
+
+		super.visit(traitsExp);
+
+		if (traitsExp.args is null)
+			return;
+
+		(*traitsExp.args).opSlice()
+			.map!(arg => isType(arg))
+			.filter!(type => type !is null)
+			.map!(type => type.isTypeIdentifier())
+			.filter!(typeIdentifier => typeIdentifier !is null)
+			.each!(typeIdentifier => markAsUsed(cast(string) typeIdentifier.toString()));
+	}
+
+	private extern (D) void markAsUsed(string varName)
+	{
+		import std.range : retro;
+
+		foreach (funcScope; usedParams.retro())
+		{
+			if (varName in funcScope)
 			{
-				interestDepth++;
-				parameter.default_.accept(this);
-				interestDepth--;
+				funcScope[varName].isUsed = true;
+				break;
 			}
 		}
+	}
+
+	@property private extern (D) ParamSet currentScope()
+	{
+		return usedParams[$ - 1];
+	}
+
+	private void pushScope()
+	{
+		usedParams ~= new ParamSet;
+	}
+
+	private void popScope()
+	{
+		usedParams.length--;
 	}
 }
 
@@ -57,11 +157,12 @@ final class UnusedParameterCheck : UnusedStorageCheck
 {
 	import std.stdio : stderr;
 	import dscanner.analysis.config : StaticAnalysisConfig, Check, disabledConfig;
-	import dscanner.analysis.helpers : assertAnalyzerWarnings;
+	import dscanner.analysis.helpers : assertAnalyzerWarningsDMD;
 
 	StaticAnalysisConfig sac = disabledConfig();
 	sac.unused_parameter_check = Check.enabled;
-	assertAnalyzerWarnings(q{
+
+	assertAnalyzerWarningsDMD(q{
 
 	// bug encountered after correct DIP 1009 impl in dparse
 	version (StdDdoc)
@@ -71,11 +172,9 @@ final class UnusedParameterCheck : UnusedStorageCheck
 			is(StringTypeOf!R));
 	}
 
-	void inPSC(in int a){} /+
-	                  ^ [warn]: Parameter a is never used. +/
+	void inPSC(in int a){} // [warn]: Parameter a is never used.
 
-	void doStuff(int a, int b) /+
-	                        ^ [warn]: Parameter b is never used. +/
+	void doStuff(int a, int b) // [warn]: Parameter b is never used.
 	{
 		return a;
 	}
@@ -96,8 +195,7 @@ final class UnusedParameterCheck : UnusedStorageCheck
 	{
 		auto cb1 = delegate(size_t _) {};
 		cb1(3);
-		auto cb2 = delegate(size_t a) {}; /+
-		                           ^ [warn]: Parameter a is never used. +/
+		auto cb2 = delegate(size_t a) {}; // [warn]: Parameter a is never used.
 		cb2(3);
 	}
 
@@ -118,5 +216,68 @@ final class UnusedParameterCheck : UnusedStorageCheck
 	}
 
 	}c, sac);
+
+	assertAnalyzerWarningsDMD(q{
+		void testMixinExpression(const Declaration decl)
+		{
+			foreach (property; possibleDeclarations)
+				if (auto fn = mixin("decl." ~ property))
+					addMessage(fn.name.type ? [fn.name] : fn.tokens, fn.name.text);
+		}
+	}c, sac);
+
+	assertAnalyzerWarningsDMD(q{
+		void testNestedFunction(int a)
+		{
+			int nestedFunction(int b)
+			{
+				return a + b;
+			}
+
+			nestedFunction(5);
+		}
+
+		void testNestedFunctionShadowing(int a) // [warn]: Parameter a is never used.
+		{
+			int nestedFunctionShadowing(int a)
+			{
+				return a + 5;
+			}
+
+			nestedFunction(5);
+		}
+	}c, sac);
+
+	assertAnalyzerWarningsDMD(q{
+		override protected void testOverrideFunction(int a)
+		{
+			return;
+		}
+	}c, sac);
+
+	assertAnalyzerWarningsDMD(q{
+		void testRefParam(ref LogEntry payload)
+		{
+			return;
+		}
+
+		void testOutParam(out LogEntry payload)
+		{
+			return;
+		}
+
+		void testPointerParam(LogEntry* payload)
+		{
+			return;
+		}
+	}c, sac);
+
+	assertAnalyzerWarningsDMD(q{
+		private char[] testStaticArray(size_t size) @safe pure nothrow
+		{
+    		return new char[size];
+		}
+	}c, sac);
+
 	stderr.writeln("Unittest for UnusedParameterCheck passed.");
 }


### PR DESCRIPTION
This check warns for unused function parameters, with the following exceptions:
- functions with no bodies are ignored;
- function overrides are ignored;
- parameters having only '_' chars in their name are ignored;
- parameters passed as pointers are ignored;
- parameters having 'ref' or 'out' are ignored;

This visitor inherits a common chain of visitors also used for UnusedVariableCheck ([UnusedIdentifierCheck](https://github.com/Dlang-UPB/D-scanner/blob/replace_libdparse/src/dscanner/analysis/unused.d#L18) and [UnusedStorageCheck](https://github.com/Dlang-UPB/D-scanner/blob/replace_libdparse/src/dscanner/analysis/unused.d#L404). I've decided to move this check to DMD without moving it's parent classes, since most of the base class functionality is needed for the unused var check.

My approach for this visitor is:
- create a "scope" (array of AA containing some var metadata) when visiting a function;
- check the unused params in the scope only if the function should be checked;
- when visiting a Parameter, add it's metadata to the current scope;
- when visiting an identifier expression, mark the parameter as used, if it exists;
- if visiting a string expression inside a mixin statement, try to look for any of the current scope params in the string literal;
- visit '__traits' expression and mark as used the expression's arguments having the identifier type;
- when checking if a param is used, if a param is not found in the current scope, the parent scopes are checked in order to cover local function cases.

I've also added extra tests for override functions and ref / out / pointer params.
Also, the check is not 100% correct. Given the following example:
```
void testNested(int a)
{
	int nested(int b)
	{
		int a = 5;
		return a + b;
	}

	nested(3);
}
```
The libdparse visitor fails to warn for unused param 'a' in 'testNested'. I've kept the same behavior in DMD version.