### PR TITLE
Replace libdparse with DMD in FunctionAttributeCheck

### DIFF
--- a/src/dscanner/analysis/function_attributes.d
+++ b/src/dscanner/analysis/function_attributes.d
@@ -89,7 +89,7 @@ extern (C++) class FunctionAttributeCheck(AST) : BaseAnalyzerDmd
 
 	override void visit(AST.FuncDeclaration fd)
 	{
-		import std.algorithm : canFind, filter, until;
+		import std.algorithm : canFind, find, filter, until;
 		import std.array : array;
 		import std.range : retro;
 
@@ -105,7 +105,21 @@ extern (C++) class FunctionAttributeCheck(AST) : BaseAnalyzerDmd
 		{
 			immutable bool isAbstract = (fd.storage_class & STC.abstract_) > 0;
 			if (isAbstract)
-				addErrorMessage(lineNum, charNum, KEY, ABSTRACT_MSG);
+			{
+				auto offset = tokens.filter!(t => t.loc.linnum >= fd.loc.linnum)
+					.until!(t => t.value == TOK.leftCurly)
+					.array
+					.retro()
+					.find!(t => t.value == TOK.abstract_)
+					.front.loc.fileOffset;
+
+				addErrorMessage(
+					lineNum, charNum, KEY, ABSTRACT_MSG,
+					[AutoFix.replacement(offset, offset + 8, "", "Remove `abstract` attribute")]
+				);
+
+				return;
+			}
 		}
 
 		auto tf = fd.type.isTypeFunction();
@@ -113,27 +127,73 @@ extern (C++) class FunctionAttributeCheck(AST) : BaseAnalyzerDmd
 		if (inAggregate && tf)
 		{
 			string storageTok = getConstLikeStorage(tf.mod);
+			auto bodyStartToken = TOK.leftCurly;
+			if (fd.fbody is null)
+				bodyStartToken = TOK.semicolon;
+
 			Token[] funcTokens = tokens.filter!(t => t.loc.fileOffset > fd.loc.fileOffset)
-				.until!(t => t.value == TOK.leftCurly)
+				.until!(t => t.value == TOK.leftCurly || t.value == bodyStartToken)
 				.array;
 
 			if (storageTok is null)
 			{
 				bool isStatic = (fd.storage_class & STC.static_) > 0;
 				bool isZeroParamProperty = tf.isProperty() && tf.parameterList.parameters.length == 0;
-				auto propertyIsAfterFunc = funcTokens.retro()
+				auto propertyRange = funcTokens.retro()
 					.until!(t => t.value == TOK.rightParenthesis)
-					.canFind!(t => t.ident.toString() == "property");
+					.find!(t => t.ident.toString() == "property")
+					.find!(t => t.value == TOK.at);
 
-				if (!isStatic && isZeroParamProperty && propertyIsAfterFunc)
-					addErrorMessage(lineNum, charNum, KEY, CONST_MSG);
+				if (!isStatic && isZeroParamProperty && !propertyRange.empty)
+					addErrorMessage(
+						lineNum, charNum, KEY, CONST_MSG,
+						[
+							AutoFix.insertionAt(propertyRange.front.loc.fileOffset, "const "),
+							AutoFix.insertionAt(propertyRange.front.loc.fileOffset, "inout "),
+							AutoFix.insertionAt(propertyRange.front.loc.fileOffset, "immutable "),
+						]
+					);
 			}
 			else
 			{
 				bool hasConstLikeAttribute = funcTokens.retro()
 					.canFind!(t => t.value == TOK.const_ || t.value == TOK.immutable_ || t.value == TOK.inout_);
+
 				if (!hasConstLikeAttribute)
-					addErrorMessage(lineNum, charNum, KEY, RETURN_MSG.format(storageTok));
+				{
+					auto funcRange = tokens.filter!(t => t.loc.linnum >= fd.loc.linnum)
+						.until!(t => t.value == TOK.leftCurly || t.value == TOK.semicolon);
+					auto parensToken = funcRange.until!(t => t.value == TOK.leftParenthesis)
+						.array
+						.retro()
+						.front;
+					auto funcEndToken = funcRange.array
+						.retro()
+						.find!(t => t.value == TOK.rightParenthesis)
+						.front;
+					auto constLikeToken = funcRange
+						.find!(t => t.value == TOK.const_ || t.value == TOK.inout_ || t.value == TOK.immutable_)
+						.front;
+
+					string modifier;
+					if (constLikeToken.value == TOK.const_)
+						modifier = " const";
+					else if (constLikeToken.value == TOK.inout_)
+						modifier = " inout";
+					else
+						modifier = " immutable";
+
+					AutoFix fix1 = AutoFix
+						.replacement(constLikeToken.loc.fileOffset, constLikeToken.loc.fileOffset + modifier.length,
+							"", "Move" ~ modifier ~ " after parameter list")
+						.concat(AutoFix.insertionAt(funcEndToken.loc.fileOffset + 1, modifier));
+
+					AutoFix fix2 = AutoFix.replacement(constLikeToken.loc.fileOffset + modifier.length - 1,
+							constLikeToken.loc.fileOffset + modifier.length, "(", "Make return type" ~ modifier)
+						.concat(AutoFix.insertionAt(parensToken.loc.fileOffset - 1, ")"));
+
+					addErrorMessage(lineNum, charNum, KEY, RETURN_MSG.format(storageTok), [fix1, fix2]);
+				}
 			}
 		}
 	}
@@ -156,7 +216,7 @@ extern (C++) class FunctionAttributeCheck(AST) : BaseAnalyzerDmd
 unittest
 {
 	import dscanner.analysis.config : Check, disabledConfig, StaticAnalysisConfig;
-	import dscanner.analysis.helpers : assertAnalyzerWarningsDMD;
+	import dscanner.analysis.helpers : assertAnalyzerWarningsDMD, assertAutoFix;
 	import std.stdio : stderr;
 
 	StaticAnalysisConfig sac = disabledConfig();
@@ -206,7 +266,6 @@ unittest
 		}
 	}c, sac);
 
-/* TODO: Fix AutoFix
 	assertAutoFix(q{
 		int foo() @property { return 0; }
 
@@ -257,8 +316,7 @@ unittest
 
 			int method(); // fix
 		}
-	}c, sac);
-	*/
+	}c, sac, true);
 
 	stderr.writeln("Unittest for ObjectConstCheck passed.");
 }

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -655,6 +655,11 @@ BaseAnalyzer[] getAnalyzersForModuleAndConfig(string fileName,
 		moduleScope
 	);
 
+	// Add those lines to suppress warnings about unused variables until cleanup is complete
+	bool ignoreVar = analysisConfig.if_constraints_indent == Check.skipTests;
+	bool ignoreVar2 = args.skipTests;
+	ignoreVar = ignoreVar || ignoreVar2;
+
 	return checks;
 }
 

--- a/src/dscanner/analysis/run.d
+++ b/src/dscanner/analysis/run.d
@@ -655,10 +655,6 @@ BaseAnalyzer[] getAnalyzersForModuleAndConfig(string fileName,
 		moduleScope
 	);
 
-	if (moduleName.shouldRun!FunctionAttributeCheck(analysisConfig))
-		checks ~= new FunctionAttributeCheck(args.setSkipTests(
-		analysisConfig.function_attribute_check == Check.skipTests && !ut));
-
 	return checks;
 }
 

--- a/src/dscanner/analysis/rundmd.d
+++ b/src/dscanner/analysis/rundmd.d
@@ -24,6 +24,7 @@ import dscanner.analysis.del : DeleteCheck;
 import dscanner.analysis.enumarrayliteral : EnumArrayVisitor;
 import dscanner.analysis.explicitly_annotated_unittests : ExplicitlyAnnotatedUnittestCheck;
 import dscanner.analysis.final_attribute : FinalAttributeChecker;
+import dscanner.analysis.function_attributes : FunctionAttributeCheck;
 import dscanner.analysis.has_public_example : HasPublicExampleCheck;
 import dscanner.analysis.if_constraints_indent : IfConstraintsIndentCheck;
 import dscanner.analysis.ifelsesame : IfElseSameCheck;
@@ -344,6 +345,12 @@ MessageSet analyzeDmd(string fileName, ASTCodegen.Module m, const char[] moduleN
 		visitors ~= new UndocumentedDeclarationCheck!ASTCodegen(
 			fileName,
 			config.undocumented_declaration_check == Check.skipTests && !ut
+		);
+
+	if (moduleName.shouldRunDmd!(FunctionAttributeCheck!ASTCodegen)(config))
+		visitors ~= new FunctionAttributeCheck!ASTCodegen(
+			fileName,
+			config.function_attribute_check == Check.skipTests && !ut
 		);
 
 	foreach (visitor; visitors)


### PR DESCRIPTION
https://github.com/Dlang-UPB/D-scanner/pull/100 fixed, only this time the check warns only for the `@property` attribute at the end of the function attribute, keeping the exact same behavior